### PR TITLE
Adapt file paths for Windows and UNIX compatibility

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,7 @@
-CRAWLING_OUTPUT_FOLDER = 'data/crawling-output/'
-SCORING_OUTPUT_FOLDER = 'data/scoring-output/'
-WEB_INPUT_FOLDER = 'docs/data/'
+from os import path
+
+CRAWLING_OUTPUT_FOLDER = path.join('data', 'crawling-output', '')
+SCORING_OUTPUT_FOLDER = path.join('data', 'scoring-output', '')
+WEB_INPUT_FOLDER = path.join('docs','data', '')
 
 YEAR = "2020"

--- a/src/crawl/unicrawl/spiders/ecam_courses.py
+++ b/src/crawl/unicrawl/spiders/ecam_courses.py
@@ -23,7 +23,7 @@ class ECAMCourseSpider(scrapy.Spider, ABC):
     name = "ecam-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ecam_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ecam_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/ecam_programs.py
+++ b/src/crawl/unicrawl/spiders/ecam_programs.py
@@ -18,7 +18,7 @@ class ECAMProgramSpider(scrapy.Spider, ABC):
     name = "ecam-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ecam_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ecam_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/he-ferrer_courses.py
+++ b/src/crawl/unicrawl/spiders/he-ferrer_courses.py
@@ -20,7 +20,7 @@ class HECHCourseSpider(scrapy.Spider, ABC):
     name = "he-ferrer-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}he-ferrer_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}he-ferrer_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/he-ferrer_programs.py
+++ b/src/crawl/unicrawl/spiders/he-ferrer_programs.py
@@ -19,7 +19,7 @@ class HEFERRERProgramSpider(scrapy.Spider, ABC):
     name = "he-ferrer-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}he-ferrer_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}he-ferrer_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/heaj_courses.py
+++ b/src/crawl/unicrawl/spiders/heaj_courses.py
@@ -25,7 +25,7 @@ class HECHCourseSpider(scrapy.Spider, ABC):
     name = "heaj-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}heaj_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}heaj_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/heaj_programs.py
+++ b/src/crawl/unicrawl/spiders/heaj_programs.py
@@ -20,7 +20,7 @@ class HEAJProgramSpider(scrapy.Spider, ABC):
     name = "heaj-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}heaj_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}heaj_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/hech_courses.py
+++ b/src/crawl/unicrawl/spiders/hech_courses.py
@@ -25,7 +25,7 @@ class HECHCourseSpider(scrapy.Spider, ABC):
     name = "hech-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}hech_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}hech_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/hech_programs.py
+++ b/src/crawl/unicrawl/spiders/hech_programs.py
@@ -21,7 +21,7 @@ class HECHProgramSpider(scrapy.Spider, ABC):
     name = "hech-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}hech_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}hech_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/hel_courses.py
+++ b/src/crawl/unicrawl/spiders/hel_courses.py
@@ -18,7 +18,7 @@ class HELCourseSpider(scrapy.Spider, ABC):
     name = "hel-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}hel_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}hel_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/hel_programs.py
+++ b/src/crawl/unicrawl/spiders/hel_programs.py
@@ -17,7 +17,7 @@ class HELProgramSpider(scrapy.Spider, ABC):
     name = "hel-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}hel_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}hel_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/heldb_courses.py
+++ b/src/crawl/unicrawl/spiders/heldb_courses.py
@@ -20,7 +20,7 @@ class HELDBCourseSpider(scrapy.Spider, ABC):
     name = "heldb-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}heldb_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}heldb_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/heldb_programs.py
+++ b/src/crawl/unicrawl/spiders/heldb_programs.py
@@ -18,7 +18,7 @@ class HELDBProgramSpider(scrapy.Spider, ABC):
     name = "heldb-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}heldb_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}heldb_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/helmo_courses.py
+++ b/src/crawl/unicrawl/spiders/helmo_courses.py
@@ -24,7 +24,7 @@ class HELMOCourseSpider(scrapy.Spider, ABC):
     name = "helmo-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}helmo_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}helmo_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/helmo_programs.py
+++ b/src/crawl/unicrawl/spiders/helmo_programs.py
@@ -22,7 +22,7 @@ class HELMOProgramSpider(scrapy.Spider, ABC):
     name = "helmo-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}helmo_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}helmo_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/henallux_courses.py
+++ b/src/crawl/unicrawl/spiders/henallux_courses.py
@@ -22,7 +22,7 @@ class HENALLUXCourseSpider(scrapy.Spider, ABC):
     name = "henallux-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}henallux_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}henallux_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/henallux_programs.py
+++ b/src/crawl/unicrawl/spiders/henallux_programs.py
@@ -17,7 +17,7 @@ class HENALLUXProgramSpider(scrapy.Spider, ABC):
     name = "henallux-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}henallux_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}henallux_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/hers_courses.py
+++ b/src/crawl/unicrawl/spiders/hers_courses.py
@@ -25,7 +25,7 @@ class HERSCourseSpider(scrapy.Spider, ABC):
     name = "hers-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}hers_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}hers_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/hers_programs.py
+++ b/src/crawl/unicrawl/spiders/hers_programs.py
@@ -22,7 +22,7 @@ class HERSProgramSpider(scrapy.Spider, ABC):
     name = "hers-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}hers_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}hers_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/ichec_courses.py
+++ b/src/crawl/unicrawl/spiders/ichec_courses.py
@@ -20,7 +20,7 @@ class ICHECCourseSpider(scrapy.Spider, ABC):
     name = "ichec-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ichec_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ichec_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/ichec_programs.py
+++ b/src/crawl/unicrawl/spiders/ichec_programs.py
@@ -17,7 +17,7 @@ class ICHECProgramSpider(scrapy.Spider, ABC):
     name = "ichec-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ichec_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ichec_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/kuleuven_courses.py
+++ b/src/crawl/unicrawl/spiders/kuleuven_courses.py
@@ -42,7 +42,7 @@ class KULeuvenCourseSpider(scrapy.Spider, ABC):
     name = "kuleuven-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}kuleuven_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}kuleuven_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/kuleuven_programs.py
+++ b/src/crawl/unicrawl/spiders/kuleuven_programs.py
@@ -12,7 +12,7 @@ class KULeuvenProgramSpider(scrapy.Spider, ABC):
     name = 'kuleuven-programs'
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}kuleuven_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}kuleuven_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/odisee_courses.py
+++ b/src/crawl/unicrawl/spiders/odisee_courses.py
@@ -27,7 +27,7 @@ class OdiseeCourseSpider(scrapy.Spider, ABC):
     name = "odisee-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}odisee_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}odisee_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/odisee_programs.py
+++ b/src/crawl/unicrawl/spiders/odisee_programs.py
@@ -12,7 +12,7 @@ class OdiseeProgramSpider(scrapy.Spider, ABC):
     name = 'odisee-programs'
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}odisee_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}odisee_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/thomasmore_courses.py
+++ b/src/crawl/unicrawl/spiders/thomasmore_courses.py
@@ -27,7 +27,7 @@ class ThomasMoreCourseSpider(scrapy.Spider, ABC):
     name = "thomasmore-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}thomasmore_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}thomasmore_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/thomasmore_programs.py
+++ b/src/crawl/unicrawl/spiders/thomasmore_programs.py
@@ -12,7 +12,7 @@ class ThomasMoreProgramSpider(scrapy.Spider, ABC):
     name = 'thomasmore-programs'
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}thomasmore_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}thomasmore_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/uantwerp_courses.py
+++ b/src/crawl/unicrawl/spiders/uantwerp_courses.py
@@ -26,7 +26,7 @@ class UantwerpCourseSpider(scrapy.Spider, ABC):
     name = "uantwerp-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}uantwerp_courses_{YEAR}_pre.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}uantwerp_courses_{YEAR}_pre.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/uantwerp_programs.py
+++ b/src/crawl/unicrawl/spiders/uantwerp_programs.py
@@ -51,7 +51,7 @@ class UantwerpProgramSpider(scrapy.Spider, ABC):
     name = "uantwerp-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}uantwerp_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}uantwerp_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/ucl_courses.py
+++ b/src/crawl/unicrawl/spiders/ucl_courses.py
@@ -31,7 +31,7 @@ class UCLCourseSpider(scrapy.Spider, ABC):
     name = "ucl-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ucl_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ucl_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/ucl_programs.py
+++ b/src/crawl/unicrawl/spiders/ucl_programs.py
@@ -14,7 +14,7 @@ class UCLProgramSpider(scrapy.Spider, ABC):
     name = "ucl-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ucl_programs_{YEAR}_pre.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ucl_programs_{YEAR}_pre.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/ucll_courses.py
+++ b/src/crawl/unicrawl/spiders/ucll_courses.py
@@ -27,7 +27,7 @@ class UCLLCourseSpider(scrapy.Spider, ABC):
     name = "ucll-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ucll_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ucll_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/ucll_programs.py
+++ b/src/crawl/unicrawl/spiders/ucll_programs.py
@@ -12,7 +12,7 @@ class UCLLProgramSpider(scrapy.Spider, ABC):
     name = 'ucll-programs'
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ucll_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ucll_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/ugent_programs.py
+++ b/src/crawl/unicrawl/spiders/ugent_programs.py
@@ -12,7 +12,7 @@ class UGentProgramSpider(scrapy.Spider, ABC):
     name = 'ugent-programs'
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ugent_programs_{YEAR}_pre.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ugent_programs_{YEAR}_pre.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/uhasselt_courses.py
+++ b/src/crawl/unicrawl/spiders/uhasselt_courses.py
@@ -19,7 +19,7 @@ class UHasseltCourseSpider(scrapy.Spider, ABC):
     name = "uhasselt-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}uhasselt_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}uhasselt_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/uhasselt_programs.py
+++ b/src/crawl/unicrawl/spiders/uhasselt_programs.py
@@ -77,7 +77,7 @@ class UHasseltProgramSpider(scrapy.Spider, ABC):
     name = 'uhasselt-programs'
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}uhasselt_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}uhasselt_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/ulb_courses.py
+++ b/src/crawl/unicrawl/spiders/ulb_courses.py
@@ -43,7 +43,7 @@ class ULBCourseSpider(scrapy.Spider, ABC):
     name = 'ulb-courses'
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ulb_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ulb_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/ulb_programs.py
+++ b/src/crawl/unicrawl/spiders/ulb_programs.py
@@ -21,7 +21,7 @@ class ULBProgramSpider(scrapy.Spider, ABC):
     name = 'ulb-programs'
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}ulb_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}ulb_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/uliege_courses.py
+++ b/src/crawl/unicrawl/spiders/uliege_courses.py
@@ -22,7 +22,7 @@ class ULiegeCourseSpider(scrapy.Spider, ABC):
     name = "uliege-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}uliege_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}uliege_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/uliege_programs.py
+++ b/src/crawl/unicrawl/spiders/uliege_programs.py
@@ -28,7 +28,7 @@ class ULiegeSpider(scrapy.Spider, ABC):
     name = 'uliege-programs'
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}uliege_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}uliege_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/umons_courses.py
+++ b/src/crawl/unicrawl/spiders/umons_courses.py
@@ -34,7 +34,7 @@ class UmonsCourseSpider(scrapy.Spider, ABC):
     name = "umons-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}umons_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}umons_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/umons_programs.py
+++ b/src/crawl/unicrawl/spiders/umons_programs.py
@@ -12,7 +12,7 @@ class UmonsProgramSpider(scrapy.Spider, ABC):
     name = "umons-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}umons_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}umons_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/unamur_courses.py
+++ b/src/crawl/unicrawl/spiders/unamur_courses.py
@@ -24,7 +24,7 @@ class UNamurCourseSpider(scrapy.Spider, ABC):
     name = "unamur-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}unamur_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}unamur_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/unamur_programs.py
+++ b/src/crawl/unicrawl/spiders/unamur_programs.py
@@ -14,7 +14,7 @@ class UNamurProgramSpider(scrapy.Spider, ABC):
     name = "unamur-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}unamur_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}unamur_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/uslb_courses.py
+++ b/src/crawl/unicrawl/spiders/uslb_courses.py
@@ -29,7 +29,7 @@ class USLBCoursesSpider(scrapy.Spider, ABC):
     name = "uslb-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}uslb_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}uslb_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/uslb_programs.py
+++ b/src/crawl/unicrawl/spiders/uslb_programs.py
@@ -22,7 +22,7 @@ class USLBProgramsSpider(scrapy.Spider, ABC):
     name = "uslb-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}uslb_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}uslb_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/vinci_courses.py
+++ b/src/crawl/unicrawl/spiders/vinci_courses.py
@@ -25,7 +25,7 @@ class VINCICourseSpider(scrapy.Spider, ABC):
     name = "vinci-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}vinci_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}vinci_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/vinci_programs.py
+++ b/src/crawl/unicrawl/spiders/vinci_programs.py
@@ -23,7 +23,7 @@ class VINCIProgramSpider(scrapy.Spider, ABC):
     name = "vinci-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}vinci_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}vinci_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/vives_courses.py
+++ b/src/crawl/unicrawl/spiders/vives_courses.py
@@ -27,7 +27,7 @@ class VivesCourseSpider(scrapy.Spider, ABC):
     name = "vives-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}vives_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}vives_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/vives_programs.py
+++ b/src/crawl/unicrawl/spiders/vives_programs.py
@@ -12,7 +12,7 @@ class VivesProgramSpider(scrapy.Spider, ABC):
     name = 'vives-programs'
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}vives_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}vives_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/vub_courses.py
+++ b/src/crawl/unicrawl/spiders/vub_courses.py
@@ -28,7 +28,7 @@ class VUBCourseSpider(scrapy.Spider, ABC):
     name = "vub-courses"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}vub_courses_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}vub_courses_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):

--- a/src/crawl/unicrawl/spiders/vub_programs.py
+++ b/src/crawl/unicrawl/spiders/vub_programs.py
@@ -14,7 +14,7 @@ class VUBProgramSpider(scrapy.Spider, ABC):
     name = "vub-programs"
     custom_settings = {
         'FEED_URI': Path(__file__).parent.absolute().joinpath(
-            f'../../../../{CRAWLING_OUTPUT_FOLDER}vub_programs_{YEAR}.json')
+            f'../../../../{CRAWLING_OUTPUT_FOLDER}vub_programs_{YEAR}.json').as_uri()
     }
 
     def start_requests(self):


### PR DESCRIPTION
This pull request addresses two issues that occured in Windows: 
- The difference in file path separators between Windows and UNIX systems prevented Snakemake command line rules from running on Windows. The paths of the output files in `Snakefile` rules were not recognized by Windows. This has been documented [here](https://github.com/snakemake/snakemake/issues/46).
- Convention for URI differ slightly in Windows. As a result, the feeds of crawling spiders were not written to json files in Windows (at least on my machine). A slight adjustement was needed in all spiders custom settings.

I tried to make the smallest possible changes required to fix those issues. The chosen solution has been tested successfully on Windows 10 and on Linux Mint.